### PR TITLE
docs: Update PRD README with Auth PRD v1 link and related issues

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -6,9 +6,18 @@ This directory contains the Product Requirements Document for Disney AI+.
 
 ## Documentation
 
-For the full PRD, see our [Notion document](TBD).
+### Authentication PRD v1
 
----
+- **Full PRD**: [Auth PRD v1 (Notion)](https://www.notion.so/2a086e7c70d081179997e8bad9d76bcf)
+- **Architecture Diagram**: [docs/diagrams/authorization-architecture.md](../diagrams/authorization-architecture.md)
 
-*Note: Link to Notion will be added once the PRD is finalized.*
+### Related GitHub Issues
 
+- [#11](https://github.com/SevDev21/disney-ai-plus/issues/11): Set up authentication service infrastructure
+- [#12](https://github.com/SevDev21/disney-ai-plus/issues/12): Implement user sign-up flow
+- [#13](https://github.com/SevDev21/disney-ai-plus/issues/13): Implement user sign-in flow
+- [#14](https://github.com/SevDev21/disney-ai-plus/issues/14): Implement token refresh mechanism
+- [#15](https://github.com/SevDev21/disney-ai-plus/issues/15): Implement user sign-out flow
+- [#16](https://github.com/SevDev21/disney-ai-plus/issues/16): Implement password reset flow
+- [#17](https://github.com/SevDev21/disney-ai-plus/issues/17): Add API authorization middleware
+- [#18](https://github.com/SevDev21/disney-ai-plus/issues/18): Add authentication QA test suite


### PR DESCRIPTION
This PR updates the PRD README to include:

- Link to the Auth PRD v1 Notion page
- Link to the authorization architecture diagram
- Complete list of all 8 authentication-related GitHub issues (#11-#18)

## Changes

- Added Authentication PRD v1 section with Notion link
- Added reference to architecture diagram
- Added bullet list of all 8 auth issues with links

Related to: #11, #12, #13, #14, #15, #16, #17, #18